### PR TITLE
Audionuma macos includes

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -25,7 +25,11 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <errno.h>
+#if defined(__linux__)
 #include <linux/limits.h>	// NAME_MAX
+#elif defined(__APPLE__)
+#include <sys/syslimits.h>
+#endif
 
 #include "file.h"
 #include "libriff.h"

--- a/src/wavfix.c
+++ b/src/wavfix.c
@@ -29,7 +29,11 @@
 #include <errno.h>
 #include <getopt.h>
 #include <stdarg.h>		// va_start();
-#include <linux/limits.h>       // NAME_MAX
+#if defined(__linux__)
+#include <linux/limits.h>	// NAME_MAX
+#elif defined(__APPLE__)
+#include <sys/syslimits.h>
+#endif
 
 #include "libriff.h"
 #include "libwav.h"


### PR DESCRIPTION
Setup conditional includes to find the `NAME_MAX` macro on Mac OS X+ 